### PR TITLE
Fix partial exclusion for Ruby 1.8

### DIFF
--- a/lib/guard/less.rb
+++ b/lib/guard/less.rb
@@ -43,7 +43,7 @@ module Guard
     def run(paths)
       last_passed = false
       paths.each do |file|
-        unless File.basename(file)[0] == "_"
+        unless File.basename(file)[0,1] == "_"
           UI.info "lessc - #{file}\n"
           last_passed = system("lessc #{file} --verbose")
         end


### PR DESCRIPTION
`str[Fixnum]` in 1.9 returns the `chr` equivalent of the index position,
but 1.8 returned the character code. Using the `[offset, length]` form
should work portably here.
