### PR TITLE
Updated dependent less gem version to 2.1.0 

### DIFF
--- a/guard-less.gemspec
+++ b/guard-less.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # s.rubyforge_project         = 'guard-less'
   
   s.add_dependency 'guard', '>= 0.2.2'
-  s.add_dependency 'less',  '~> 2.0.5'
+  s.add_dependency 'less',  '~> 2.1.0'
 
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'fakefs',      '~> 0.3'


### PR DESCRIPTION
When i use this guard-less gem on my new rails project to compile Twitter Bootstrap framework, some error occurred. So I updated this guard-less' depencent less gem version from 2.0.x to 2.1.x.
