### PR TITLE
Bumping up Dependent Less Version to 2.2.x

### DIFF
--- a/guard-less.gemspec
+++ b/guard-less.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # s.rubyforge_project         = 'guard-less'
   
   s.add_dependency 'guard', '>= 0.2.2'
-  s.add_dependency 'less',  '~> 2.1.0'
+  s.add_dependency 'less',  '~> 2.2.0'
 
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'fakefs',      '~> 0.3'


### PR DESCRIPTION
Updating dependent less gem so that guard-less can work with less 2.2.x
